### PR TITLE
chore: point pyright at the project .venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ docs = [
     "sphinx-design",
 ]
 
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+
 [dependency-groups]
 dev = [
     "furo>=2025.12.19",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `[tool.pyright]` section so Pyright resolves imports against the project's `.venv` rather than a global environment:

```toml
[tool.pyright]
venvPath = "."
venv = ".venv"
```

This makes editor/CI type-checking see the installed dependencies (pandas, panel, etc.), reducing spurious "could not be resolved" import errors. No runtime impact.